### PR TITLE
Dev/0.0.3 lambda signatures

### DIFF
--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
@@ -31,7 +31,15 @@ object Napier {
         log(Level.VERBOSE, tag, throwable, message)
     }
 
+    fun v(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.VERBOSE, tag, throwable, message)
+    }
+
     fun i(message: String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.INFO, tag, throwable, message)
+    }
+
+    fun i(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
         log(Level.INFO, tag, throwable, message)
     }
 
@@ -39,7 +47,15 @@ object Napier {
         log(Level.DEBUG, tag, throwable, message)
     }
 
+    fun d(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.DEBUG, tag, throwable, message)
+    }
+
     fun w(message: String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.WARNING, tag, throwable, message)
+    }
+
+    fun w(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
         log(Level.WARNING, tag, throwable, message)
     }
 
@@ -47,13 +63,27 @@ object Napier {
         log(Level.ERROR, tag, throwable, message)
     }
 
+    fun e(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.ERROR, tag, throwable, message)
+    }
+
     fun wtf(message: String, throwable: Throwable? = null, tag: String? = null) {
+        log(Level.ASSERT, tag, throwable, message)
+    }
+
+    fun wtf(message: ()->String, throwable: Throwable? = null, tag: String? = null) {
         log(Level.ASSERT, tag, throwable, message)
     }
 
     fun log(priority: Level, tag: String? = null, throwable: Throwable? = null, message: String) {
         if (isEnable(priority, tag)) {
             rawLog(priority, tag, throwable, message)
+        }
+    }
+
+    fun log(priority: Level, tag: String? = null, throwable: Throwable? = null, message: ()->String) {
+        if (isEnable(priority, tag)) {
+            rawLog(priority, tag, throwable, message())
         }
     }
 }


### PR DESCRIPTION
Hi! Thanks for Napier.  This PR provides a feature that no logging framework should be without: **lazily evaluated log messages**.

Each `Napier.x(...)` logging function is duplicated to additionally allow String-returning lambdas.
When using these signatures, the evaluation of messages is deferred until the required Log-level is confirmed (in `Napier.log(...)`).

This should be preferred for log messages whose String formatting incurs a significant cost: this can be avoided when in production.