### PR TITLE
Add debug publish variant for android.

### DIFF
--- a/napier/build.gradle
+++ b/napier/build.gradle
@@ -9,7 +9,7 @@ apply from: rootProject.file('gradle/publish.gradle')
 
 kotlin {
     android {
-        publishLibraryVariants("release")
+        publishAllLibraryVariants()
     }
     ios() {
         binaries {


### PR DESCRIPTION
At the moment mpp project with latest kotlin plugin has issue:
 - android source set gets JVM artifact for debug variant (during development)

Why this variant was filtered from publication?

![изображение](https://user-images.githubusercontent.com/3532155/91310951-2bebdd80-e7bb-11ea-8877-1aa7ca29ce91.png)
