### PR TITLE
Separate the LogLevel from nested in the Napier.Level

### DIFF
--- a/android/src/main/java/com/github/aakira/napier/sample/CrashlyticsAntilog.kt
+++ b/android/src/main/java/com/github/aakira/napier/sample/CrashlyticsAntilog.kt
@@ -3,13 +3,13 @@ package com.github.aakira.napier.sample
 import android.content.Context
 import com.crashlytics.android.Crashlytics
 import com.github.aakira.napier.Antilog
-import com.github.aakira.napier.Napier
+import com.github.aakira.napier.LogLevel
 
 class CrashlyticsAntilog(private val context: Context) : Antilog() {
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         // send only error log
-        if (priority < Napier.Level.ERROR) return
+        if (priority < LogLevel.ERROR) return
         Crashlytics.getInstance().core.log(priority.ordinal, tag, message)
 
         throwable?.let {

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -1,8 +1,8 @@
 package dependencies
 
 object Versions {
-    const val versionCode = 14
-    const val versionName = "1.4.1"
+    const val versionCode = 15
+    const val versionName = "1.5.0-alpha1"
 
     // android
     const val androidVersionCode = 1

--- a/mpp-sample/src/iosMain/kotlin/com/github/aakira/napier/mppsample/CrashlyticsAntilog.kt
+++ b/mpp-sample/src/iosMain/kotlin/com/github/aakira/napier/mppsample/CrashlyticsAntilog.kt
@@ -1,16 +1,16 @@
 package com.github.aakira.napier.mppsample
 
 import com.github.aakira.napier.Antilog
-import com.github.aakira.napier.Napier
+import com.github.aakira.napier.LogLevel
 
 class CrashlyticsAntilog(
     private val crashlyticsAddLog: (priority: Int, tag: String?, message: String?) -> Unit,
     private val crashlyticsSendLog: (throwable: Throwable) -> Unit
 ) : Antilog() {
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         // send only error log
-        if (priority < Napier.Level.ERROR) return
+        if (priority < LogLevel.ERROR) return
 
         crashlyticsAddLog.invoke(priority.ordinal, tag, message)
 

--- a/napier/src/androidMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/androidMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
@@ -16,7 +16,7 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
 
     private val anonymousClass = Pattern.compile("(\\$\\d+)+$")
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
 
         val debugTag = tag ?: performTag(defaultTag)
 
@@ -31,7 +31,7 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
         val length = fullMessage.length
         if (length <= MAX_LOG_LENGTH) {
             // Fast path for small messages which can fit in a single call.
-            if (priority == Napier.Level.ASSERT) {
+            if (priority == LogLevel.ASSERT) {
                 Log.wtf(debugTag, fullMessage)
             } else {
                 Log.println(priority.toValue(), debugTag, fullMessage)
@@ -95,12 +95,12 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
             return sw.toString()
         }
 
-    private fun Napier.Level.toValue() = when (this) {
-        Napier.Level.VERBOSE -> Log.VERBOSE
-        Napier.Level.DEBUG -> Log.DEBUG
-        Napier.Level.INFO -> Log.INFO
-        Napier.Level.WARNING -> Log.WARN
-        Napier.Level.ERROR -> Log.ERROR
-        Napier.Level.ASSERT -> Log.ASSERT
+    private fun LogLevel.toValue() = when (this) {
+        LogLevel.VERBOSE -> Log.VERBOSE
+        LogLevel.DEBUG -> Log.DEBUG
+        LogLevel.INFO -> Log.INFO
+        LogLevel.WARNING -> Log.WARN
+        LogLevel.ERROR -> Log.ERROR
+        LogLevel.ASSERT -> Log.ASSERT
     }
 }

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/Antilog.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/Antilog.kt
@@ -2,17 +2,17 @@ package com.github.aakira.napier
 
 abstract class Antilog {
 
-    open fun isEnable(priority: Napier.Level, tag: String?) = true
+    open fun isEnable(priority: LogLevel, tag: String?) = true
 
-    fun log(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    fun log(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         if (isEnable(priority, tag)) {
             performLog(priority, tag, throwable, message)
         }
     }
 
-    internal fun rawLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    internal fun rawLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         performLog(priority, tag, throwable, message)
     }
 
-    protected abstract fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?)
+    protected abstract fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?)
 }

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/LogLevel.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/LogLevel.kt
@@ -1,0 +1,11 @@
+package com.github.aakira.napier
+
+enum class LogLevel {
+    VERBOSE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    ASSERT,
+}
+

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
@@ -5,83 +5,74 @@ import kotlin.native.concurrent.ThreadLocal
 @ThreadLocal
 object Napier {
 
-    enum class Level {
-        VERBOSE,
-        DEBUG,
-        INFO,
-        WARNING,
-        ERROR,
-        ASSERT,
-    }
-
     private val baseArray = mutableListOf<Antilog>()
 
     fun base(antilog: Antilog) {
         baseArray.add(antilog)
     }
 
-    fun isEnable(priority: Level, tag: String?) = baseArray.any { it.isEnable(priority, tag) }
+    fun isEnable(priority: LogLevel, tag: String?) = baseArray.any { it.isEnable(priority, tag) }
 
     @PublishedApi
-    internal fun rawLog(priority: Level, tag: String?, throwable: Throwable?, message: String?) {
+    internal fun rawLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         baseArray.forEach { it.rawLog(priority, tag, throwable, message) }
     }
 
     fun v(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.VERBOSE, tag, throwable, message)
+        log(LogLevel.VERBOSE, tag, throwable, message)
     }
 
     fun v(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.VERBOSE, tag, throwable, message)
+        log(LogLevel.VERBOSE, tag, throwable, message)
     }
 
     fun i(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.INFO, tag, throwable, message)
+        log(LogLevel.INFO, tag, throwable, message)
     }
 
     fun i(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.INFO, tag, throwable, message)
+        log(LogLevel.INFO, tag, throwable, message)
     }
 
     fun d(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.DEBUG, tag, throwable, message)
+        log(LogLevel.DEBUG, tag, throwable, message)
     }
 
     fun d(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.DEBUG, tag, throwable, message)
+        log(LogLevel.DEBUG, tag, throwable, message)
     }
 
     fun w(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.WARNING, tag, throwable, message)
+        log(LogLevel.WARNING, tag, throwable, message)
     }
 
     fun w(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.WARNING, tag, throwable, message)
+        log(LogLevel.WARNING, tag, throwable, message)
     }
 
     fun e(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.ERROR, tag, throwable, message)
+        log(LogLevel.ERROR, tag, throwable, message)
     }
 
     fun e(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.ERROR, tag, throwable, message)
+        log(LogLevel.ERROR, tag, throwable, message)
     }
 
     fun wtf(message: String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.ASSERT, tag, throwable, message)
+        log(LogLevel.ASSERT, tag, throwable, message)
     }
 
     fun wtf(message: () -> String, throwable: Throwable? = null, tag: String? = null) {
-        log(Level.ASSERT, tag, throwable, message)
+        log(LogLevel.ASSERT, tag, throwable, message)
     }
 
-    fun log(priority: Level, tag: String? = null, throwable: Throwable? = null, message: String) {
+    fun log(priority: LogLevel, tag: String? = null, throwable: Throwable? = null, message: String) {
         if (isEnable(priority, tag)) {
             rawLog(priority, tag, throwable, message)
         }
     }
 
-    fun log(priority: Level, tag: String? = null, throwable: Throwable? = null, message: () -> String) {
+    fun log(priority: LogLevel, tag: String? = null, throwable: Throwable? = null, message: () -> String) {
         if (isEnable(priority, tag)) {
             rawLog(priority, tag, throwable, message())
         }

--- a/napier/src/commonTest/kotlin/com/github/aakira/napier/NapierTest.kt
+++ b/napier/src/commonTest/kotlin/com/github/aakira/napier/NapierTest.kt
@@ -12,7 +12,7 @@ class NapierTest {
     )
 
     private data class Expected(
-        val priority: Napier.Level,
+        val priority: LogLevel,
         val tag: String?,
         val throwable: Throwable?,
         val message: String?
@@ -24,7 +24,7 @@ class NapierTest {
     fun `Check output log`() {
         val output = ArrayList<Expected>()
         Napier.base(object : Antilog() {
-            override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+            override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
                 output.add(Expected(priority, tag, throwable, message))
             }
         })
@@ -34,7 +34,7 @@ class NapierTest {
                 "verbose",
                 { Napier.v("hello") },
                 Expected(
-                    Napier.Level.VERBOSE,
+                    LogLevel.VERBOSE,
                     null,
                     null,
                     "hello"
@@ -44,7 +44,7 @@ class NapierTest {
                 "debug",
                 { Napier.d("hello") },
                 Expected(
-                    Napier.Level.DEBUG,
+                    LogLevel.DEBUG,
                     null,
                     null,
                     "hello"
@@ -54,7 +54,7 @@ class NapierTest {
                 "info",
                 { Napier.i("hello") },
                 Expected(
-                    Napier.Level.INFO,
+                    LogLevel.INFO,
                     null,
                     null,
                     "hello"
@@ -64,7 +64,7 @@ class NapierTest {
                 "warning",
                 { Napier.w("hello") },
                 Expected(
-                    Napier.Level.WARNING,
+                    LogLevel.WARNING,
                     null,
                     null,
                     "hello"
@@ -74,7 +74,7 @@ class NapierTest {
                 "error",
                 { Napier.e("hello") },
                 Expected(
-                    Napier.Level.ERROR,
+                    LogLevel.ERROR,
                     null,
                     null,
                     "hello"
@@ -84,7 +84,7 @@ class NapierTest {
                 "assert",
                 { Napier.wtf("hello") },
                 Expected(
-                    Napier.Level.ASSERT,
+                    LogLevel.ASSERT,
                     null,
                     null,
                     "hello"
@@ -95,7 +95,7 @@ class NapierTest {
                 "tag verbose",
                 { Napier.v("hello", null, "tag") },
                 Expected(
-                    Napier.Level.VERBOSE,
+                    LogLevel.VERBOSE,
                     "tag",
                     null,
                     "hello"
@@ -105,7 +105,7 @@ class NapierTest {
                 "tag debug",
                 { Napier.d("hello", null, "tag") },
                 Expected(
-                    Napier.Level.DEBUG,
+                    LogLevel.DEBUG,
                     "tag",
                     null,
                     "hello"
@@ -115,7 +115,7 @@ class NapierTest {
                 "tag info",
                 { Napier.i("hello", null, "tag") },
                 Expected(
-                    Napier.Level.INFO,
+                    LogLevel.INFO,
                     "tag",
                     null,
                     "hello"
@@ -125,7 +125,7 @@ class NapierTest {
                 "tag warning",
                 { Napier.w("hello", null, "tag") },
                 Expected(
-                    Napier.Level.WARNING,
+                    LogLevel.WARNING,
                     "tag",
                     null,
                     "hello"
@@ -135,7 +135,7 @@ class NapierTest {
                 "tag error",
                 { Napier.e("hello", null, "tag") },
                 Expected(
-                    Napier.Level.ERROR,
+                    LogLevel.ERROR,
                     "tag",
                     null,
                     "hello"
@@ -145,7 +145,7 @@ class NapierTest {
                 "tag assert",
                 { Napier.wtf("hello", null, "tag") },
                 Expected(
-                    Napier.Level.ASSERT,
+                    LogLevel.ASSERT,
                     "tag",
                     null,
                     "hello"
@@ -156,7 +156,7 @@ class NapierTest {
                 "throwable verbose",
                 { Napier.v("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.VERBOSE,
+                    LogLevel.VERBOSE,
                     "tag",
                     CustomThrowable("error"),
                     "hello"
@@ -166,7 +166,7 @@ class NapierTest {
                 "throwable debug",
                 { Napier.d("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.DEBUG,
+                    LogLevel.DEBUG,
                     "tag",
                     CustomThrowable("error"),
                     "hello"
@@ -176,7 +176,7 @@ class NapierTest {
                 "throwable info",
                 { Napier.i("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.INFO,
+                    LogLevel.INFO,
                     "tag",
                     CustomThrowable("error"),
                     "hello"
@@ -186,7 +186,7 @@ class NapierTest {
                 "throwable warning",
                 { Napier.w("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.WARNING,
+                    LogLevel.WARNING,
                     "tag",
                     CustomThrowable("error"),
                     "hello"
@@ -196,7 +196,7 @@ class NapierTest {
                 "throwable error",
                 { Napier.e("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.ERROR,
+                    LogLevel.ERROR,
                     "tag",
                     CustomThrowable("error"),
                     "hello"
@@ -206,7 +206,7 @@ class NapierTest {
                 "throwable assert",
                 { Napier.wtf("hello", CustomThrowable("error"), "tag") },
                 Expected(
-                    Napier.Level.ASSERT,
+                    LogLevel.ASSERT,
                     "tag",
                     CustomThrowable("error"),
                     "hello"

--- a/napier/src/iosMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/iosMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
@@ -14,24 +14,24 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
         dateFormat = "MM-dd HH:mm:ss.SSS"
     }
 
-    private val tagMap: HashMap<Napier.Level, String> = hashMapOf(
-        Napier.Level.VERBOSE to "💜 VERBOSE",
-        Napier.Level.DEBUG to "💚 DEBUG",
-        Napier.Level.INFO to "💙 INFO",
-        Napier.Level.WARNING to "💛 WARN",
-        Napier.Level.ERROR to "❤️ ERROR",
-        Napier.Level.ASSERT to "💞 ASSERT"
+    private val tagMap: HashMap<LogLevel, String> = hashMapOf(
+        LogLevel.VERBOSE to "💜 VERBOSE",
+        LogLevel.DEBUG to "💚 DEBUG",
+        LogLevel.INFO to "💙 INFO",
+        LogLevel.WARNING to "💛 WARN",
+        LogLevel.ERROR to "❤️ ERROR",
+        LogLevel.ASSERT to "💞 ASSERT"
     )
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
-        if (priority == Napier.Level.ASSERT) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
+        if (priority == LogLevel.ASSERT) {
             assert(crashAssert) { buildLog(priority, tag, message) }
         } else {
             println(buildLog(priority, tag, message))
         }
     }
 
-    fun setTag(level: Napier.Level, tag: String) {
+    fun setTag(level: LogLevel, tag: String) {
         tagMap[level] = tag
     }
 
@@ -41,7 +41,7 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
 
     private fun getCurrentTime() = dateFormatter.stringFromDate(NSDate())
 
-    private fun buildLog(priority: Napier.Level, tag: String?, message: String?): String {
+    private fun buildLog(priority: LogLevel, tag: String?, message: String?): String {
         return "${getCurrentTime()} ${tagMap[priority]} ${tag ?: performTag(defaultTag)} - $message"
     }
 

--- a/napier/src/jsMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/jsMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
@@ -2,7 +2,7 @@ package com.github.aakira.napier
 
 class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         val logTag = tag ?: defaultTag
 
         val fullMessage = if (message != null) {
@@ -14,12 +14,12 @@ class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
         } else throwable?.message ?: return
 
         when (priority) {
-            Napier.Level.VERBOSE -> console.log("VERBOSE $logTag : $fullMessage")
-            Napier.Level.DEBUG -> console.log("DEBUG $logTag : $fullMessage")
-            Napier.Level.INFO -> console.info("INFO $logTag : $fullMessage")
-            Napier.Level.WARNING -> console.warn("WARNING $logTag : $fullMessage")
-            Napier.Level.ERROR -> console.error("ERROR $logTag : $fullMessage")
-            Napier.Level.ASSERT -> console.error("ASSERT $logTag : $fullMessage")
+            LogLevel.VERBOSE -> console.log("VERBOSE $logTag : $fullMessage")
+            LogLevel.DEBUG -> console.log("DEBUG $logTag : $fullMessage")
+            LogLevel.INFO -> console.info("INFO $logTag : $fullMessage")
+            LogLevel.WARNING -> console.warn("WARNING $logTag : $fullMessage")
+            LogLevel.ERROR -> console.error("ERROR $logTag : $fullMessage")
+            LogLevel.ASSERT -> console.error("ASSERT $logTag : $fullMessage")
         }
     }
 }

--- a/napier/src/jvmMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/jvmMain/kotlin/com/github/aakira/napier/DebugAntilog.kt
@@ -37,16 +37,16 @@ class DebugAntilog(
 
     private val anonymousClass = Pattern.compile("(\\$\\d+)+$")
 
-    private val tagMap: HashMap<Napier.Level, String> = hashMapOf(
-        Napier.Level.VERBOSE to "[VERBOSE]",
-        Napier.Level.DEBUG to "[DEBUG]",
-        Napier.Level.INFO to "[INFO]",
-        Napier.Level.WARNING to "[WARN]",
-        Napier.Level.ERROR to "[ERROR]",
-        Napier.Level.ASSERT to "[ASSERT]"
+    private val tagMap: HashMap<LogLevel, String> = hashMapOf(
+        LogLevel.VERBOSE to "[VERBOSE]",
+        LogLevel.DEBUG to "[DEBUG]",
+        LogLevel.INFO to "[INFO]",
+        LogLevel.WARNING to "[WARN]",
+        LogLevel.ERROR to "[ERROR]",
+        LogLevel.ASSERT to "[ASSERT]"
     )
 
-    override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
+    override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
 
         val debugTag = tag ?: performTag(defaultTag)
 
@@ -59,16 +59,16 @@ class DebugAntilog(
         } else throwable?.stackTraceString ?: return
 
         when (priority) {
-            Napier.Level.VERBOSE -> logger.finest(buildLog(priority, debugTag, fullMessage))
-            Napier.Level.DEBUG -> logger.fine(buildLog(priority, debugTag, fullMessage))
-            Napier.Level.INFO -> logger.info(buildLog(priority, debugTag, fullMessage))
-            Napier.Level.WARNING -> logger.warning(buildLog(priority, debugTag, fullMessage))
-            Napier.Level.ERROR -> logger.severe(buildLog(priority, debugTag, fullMessage))
-            Napier.Level.ASSERT -> logger.severe(buildLog(priority, debugTag, fullMessage))
+            LogLevel.VERBOSE -> logger.finest(buildLog(priority, debugTag, fullMessage))
+            LogLevel.DEBUG -> logger.fine(buildLog(priority, debugTag, fullMessage))
+            LogLevel.INFO -> logger.info(buildLog(priority, debugTag, fullMessage))
+            LogLevel.WARNING -> logger.warning(buildLog(priority, debugTag, fullMessage))
+            LogLevel.ERROR -> logger.severe(buildLog(priority, debugTag, fullMessage))
+            LogLevel.ASSERT -> logger.severe(buildLog(priority, debugTag, fullMessage))
         }
     }
 
-    internal fun buildLog(priority: Napier.Level, tag: String?, message: String?): String {
+    internal fun buildLog(priority: LogLevel, tag: String?, message: String?): String {
         return "${tagMap[priority]} ${tag ?: performTag(defaultTag)} - $message"
     }
 

--- a/napier/src/jvmTest/kotlin/com/github/aakira/napier/NapierJvmTest.kt
+++ b/napier/src/jvmTest/kotlin/com/github/aakira/napier/NapierJvmTest.kt
@@ -19,7 +19,7 @@ class NapierJvmTest {
     fun `Check buildLog`() {
         assertEquals(
             "[VERBOSE] defaultTag - message",
-            debugAntilog.buildLog(Napier.Level.VERBOSE, "defaultTag", "message")
+            debugAntilog.buildLog(LogLevel.VERBOSE, "defaultTag", "message")
         )
     }
 }


### PR DESCRIPTION
## Breaking changes 🚧

#43 

`Napier.Level` => `LogLevel`

e.g.

`Napier.Level.VERBOSE` => `LogLevel.VERBOSE`

You can try this version as `1.5.0-alpha1`