### PR TITLE
baseArray replaced with atomic - fix logging from another thread on iOS #56 

### DIFF
--- a/napier/src/androidMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
+++ b/napier/src/androidMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
@@ -1,0 +1,3 @@
+package com.github.aakira.napier.atomic
+
+internal actual class AtomicRef<T> actual constructor(actual var value: T)

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/Napier.kt
@@ -1,5 +1,6 @@
 package com.github.aakira.napier
 
+import com.github.aakira.napier.atomic.AtomicMutableList
 import kotlin.native.concurrent.ThreadLocal
 
 @ThreadLocal
@@ -14,7 +15,7 @@ object Napier {
         ASSERT,
     }
 
-    private val baseArray = mutableListOf<Antilog>()
+    private val baseArray = AtomicMutableList<Antilog>()
 
     fun base(antilog: Antilog) {
         baseArray.add(antilog)

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/atomic/AtomicMutableList.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/atomic/AtomicMutableList.kt
@@ -1,0 +1,53 @@
+package com.github.aakira.napier.atomic
+
+internal class AtomicMutableList<T>(value: List<T>): AbstractList<T>() {
+    constructor() : this(listOf())
+    private val atomicReference = AtomicRef(value)
+
+    fun add(element: T, index: Int = count()) =
+        modify(+1) {
+            add(index, element)
+        }
+
+    fun remove(t: T) =
+        modify(-1) {
+            remove(t)
+        }
+
+    fun clear() =
+        modify(-size) {
+            clear()
+        }
+
+    fun removeAt(index: Int): T =
+        modify(-1) {
+            removeAt(index)
+        }
+
+    fun set(index: Int, element: T): T =
+        modify(0) {
+            set(index, element)
+        }
+
+    fun dropAll(): List<T> {
+        val result = atomicReference.value
+        atomicReference.value = listOf()
+        return result
+    }
+
+    override val size: Int get() = atomicReference.value.size
+    override fun isEmpty(): Boolean = atomicReference.value.isEmpty()
+    override fun contains(element: T): Boolean = atomicReference.value.contains(element)
+    override fun get(index: Int): T = atomicReference.value[index]
+    override fun indexOf(element: T): Int = atomicReference.value.indexOf(element)
+    override fun lastIndexOf(element: T): Int = atomicReference.value.lastIndexOf(element)
+    override fun iterator(): Iterator<T> = atomicReference.value.iterator()
+
+    private fun <R> modify(capacityDiff: Int, block: ArrayList<T>.() -> R): R {
+        val newValue = ArrayList<T>(size + capacityDiff)
+        newValue.addAll(this)
+        val result = block(newValue)
+        atomicReference.value = newValue
+        return result
+    }
+}

--- a/napier/src/commonMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
+++ b/napier/src/commonMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
@@ -1,0 +1,5 @@
+package com.github.aakira.napier.atomic
+
+internal expect class AtomicRef<T>(value: T) {
+    var value: T
+}

--- a/napier/src/commonTest/kotlin/com/github/aakira/napier/NapierTest.kt
+++ b/napier/src/commonTest/kotlin/com/github/aakira/napier/NapierTest.kt
@@ -1,5 +1,6 @@
 package com.github.aakira.napier
 
+import com.github.aakira.napier.atomic.AtomicMutableList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -22,7 +23,7 @@ class NapierTest {
 
     @Test
     fun `Check output log`() {
-        val output = ArrayList<Expected>()
+        val output = AtomicMutableList<Expected>()
         Napier.base(object : Antilog() {
             override fun performLog(priority: Napier.Level, tag: String?, throwable: Throwable?, message: String?) {
                 output.add(Expected(priority, tag, throwable, message))

--- a/napier/src/iosMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
+++ b/napier/src/iosMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
@@ -1,0 +1,13 @@
+package com.github.aakira.napier.atomic
+
+import kotlin.native.concurrent.AtomicReference
+import kotlin.native.concurrent.freeze
+
+internal actual class AtomicRef<T> actual constructor(value: T) {
+    private val atomicRef = AtomicReference(value.freeze())
+    actual var value: T
+        get() = atomicRef.value
+        set(value) {
+            atomicRef.value = value.freeze()
+        }
+}

--- a/napier/src/jsMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
+++ b/napier/src/jsMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
@@ -1,0 +1,3 @@
+package com.github.aakira.napier.atomic
+
+internal actual class AtomicRef<T> actual constructor(actual var value: T)

--- a/napier/src/jvmMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
+++ b/napier/src/jvmMain/kotlin/com/github/aakira/napier/atomic/AtomicRef.kt
@@ -1,0 +1,3 @@
+package com.github.aakira.napier.atomic
+
+internal actual class AtomicRef<T> actual constructor(actual var value: T)


### PR DESCRIPTION
This is fix for #56. The problem is in iOS concurrency, which I fixed by storing antilogs in an atomic list. In order to improve performance on all platforms except iOS AtomicRef is just container for a value, without additional thread safety - as it's not needed.