### PR TITLE
DebugAntilog made common class with expect/actual

### DIFF
--- a/napier/src/androidMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/androidMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -6,7 +6,7 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.regex.Pattern
 
-class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
+actual class DebugAntilog actual constructor(private val defaultTag: String) : Antilog() {
 
     companion object {
         private const val MAX_LOG_LENGTH = 4000

--- a/napier/src/commonMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/commonMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -1,0 +1,9 @@
+package io.github.aakira.napier
+
+import android.os.Build
+import android.util.Log
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.regex.Pattern
+
+expect class DebugAntilog(defaultTag: String = "app") : Antilog

--- a/napier/src/commonMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/commonMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -1,9 +1,3 @@
 package io.github.aakira.napier
 
-import android.os.Build
-import android.util.Log
-import java.io.PrintWriter
-import java.io.StringWriter
-import java.util.regex.Pattern
-
 expect class DebugAntilog(defaultTag: String = "app") : Antilog

--- a/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -6,10 +6,11 @@ import platform.Foundation.NSThread
 
 private const val CALL_STACK_INDEX = 8
 
-class DebugAntilog(
+actual class DebugAntilog(
     private val defaultTag: String = "app",
     private val coroutinesSuffix: Boolean = true,
 ) : Antilog() {
+    actual constructor(defaultTag: String) : this(defaultTag, coroutinesSuffix = true)
 
     var crashAssert = false
 

--- a/napier/src/jsMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/jsMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -3,7 +3,7 @@ package io.github.aakira.napier
 import io.github.aakira.napier.Antilog
 import io.github.aakira.napier.Napier
 
-class DebugAntilog(private val defaultTag: String = "app") : Antilog() {
+actual class DebugAntilog actual constructor(private val defaultTag: String) : Antilog() {
 
     override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
         val logTag = tag ?: defaultTag

--- a/napier/src/jsMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/jsMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -1,8 +1,5 @@
 package io.github.aakira.napier
 
-import io.github.aakira.napier.Antilog
-import io.github.aakira.napier.Napier
-
 actual class DebugAntilog actual constructor(private val defaultTag: String) : Antilog() {
 
     override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {

--- a/napier/src/jvmMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/jvmMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -9,10 +9,11 @@ import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
 import java.util.regex.Pattern
 
-class DebugAntilog(
+actual class DebugAntilog(
     private val defaultTag: String = "app",
     private val handler: List<Handler> = listOf()
 ) : Antilog() {
+    actual constructor(defaultTag: String) : this(defaultTag, handler = listOf())
 
     companion object {
         private const val CALL_STACK_INDEX = 8


### PR DESCRIPTION
I understand that there're some cases when user may need to configure specific parameters for `DebugAntilog`, but I think it should be possible to use it with default params from common code