### PR TITLE
Refact DebugAntilog null-safety for ios

### DIFF
--- a/napier/build.gradle.kts
+++ b/napier/build.gradle.kts
@@ -158,7 +158,7 @@ kotlin {
                 val macosArm64Main by getting {
                     dependsOn(darwinMain)
                 }
-                val macosArm64Text by getting {
+                val macosArm64Test by getting {
                     dependsOn(darwinTest)
                 }
                 val iosSimulatorArm64Main by getting {

--- a/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -56,13 +56,13 @@ actual class DebugAntilog(
 
     // find stack trace
     private fun performTag(tag: String): String {
-        val thread = NSThread.callStackSymbols
+        val symbols = NSThread.callStackSymbols
+        if (symbols.size <= CALL_STACK_INDEX) return tag
 
-        return if (thread.size >= CALL_STACK_INDEX) {
-            createStackElementTag(thread[CALL_STACK_INDEX] as String)
-        } else {
-            tag
-        }
+        val target = symbols[CALL_STACK_INDEX] as? String
+
+        return if (target != null) createStackElementTag(target)
+        else tag
     }
 
     internal fun createStackElementTag(string: String): String {

--- a/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/darwinMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -59,10 +59,9 @@ actual class DebugAntilog(
         val symbols = NSThread.callStackSymbols
         if (symbols.size <= CALL_STACK_INDEX) return tag
 
-        val target = symbols[CALL_STACK_INDEX] as? String
-
-        return if (target != null) createStackElementTag(target)
-        else tag
+        return (symbols[CALL_STACK_INDEX] as? String)?.let {
+            createStackElementTag(it)
+        } ?: tag
     }
 
     internal fun createStackElementTag(string: String): String {


### PR DESCRIPTION
### Environment
- Apple M1 + xcode with rosetta
- Apple intel + xcode
- iOS 15.2 iPhone 11 simulator

### Snippets
**common module**
```kotlin
fun initKoin() { ... Napier.d("initialized koin") }
```
**AppDelegate**
```swift
func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
    ...
    NapierProxyKt.debugBuild()
    ...
    KoinKt.initKoin()
```

### Print Symbols
```
0 null
1 null
2 null
3 null
4 null
5 null
6 null
7 null
8 null <<- is null
9 null
10 null
11 null
12  UIKitCore                           0x00000001227f5f2f -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 216
13  UIKitCore                           0x00000001227f7b9f -[UIApplication _callInitializationDelegatesWithActions:forCanvas:payload:fromOriginatingProcess:] + 4115
14  UIKitCore                           0x00000001227fd50e -[UIApplication _runWithMainScene:transitionContext:completion:] + 1221
15  UIKitCore                           0x0000000121d79c7a -[_UISceneLifecycleMultiplexer completeApplicationLaunchWithFBSScene:transitionContext:] + 122
16  UIKitCore                           0x00000001223661c6 _UIScenePerformActionsWithLifecycleActionMask + 88
17  UIKitCore                           0x0000000121d7a771 __101-[_UISceneLifecycleMultiplexer
```

### Desc
- No problem with the new install. but, if re-install(build) in xcode after change code then throw `NullPointerException`.
- I check `NSThread.callStackSymbols`, it shown 'null' value.

### Solution
- `Antilog.performTag` null-safety
- I don't know why symbol value is null 😢 