### PR TITLE
Android DebugAntilog crash

### DIFF
--- a/napier/src/androidMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
+++ b/napier/src/androidMain/kotlin/io/github/aakira/napier/DebugAntilog.kt
@@ -68,7 +68,7 @@ actual class DebugAntilog actual constructor(private val defaultTag: String) : A
     private fun performTag(tag: String): String {
         val thread = Thread.currentThread().stackTrace
 
-        return if (thread.size >= CALL_STACK_INDEX) {
+        return if (thread.size > CALL_STACK_INDEX) {
             thread[CALL_STACK_INDEX].run {
                 "${createStackElementTag(className)}\$$methodName"
             }


### PR DESCRIPTION
fix DebugAntilog crash when stacktrace size exactly == 9