### PR TITLE
Improve readme regarding ios initialization code

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,13 @@ fun debugBuild() {
 }
 ```
 
-|argument|type|description| |-|-| |coroutinesSuffix|Boolean|Added `[async]` label at the end, if it is called from
-suspend functions|
+* Option) Pass `coroutinesSuffix = false` argument if you don't want `[async]` label.
+
+```kotlin
+fun debugBuild() {
+    Napier.base(DebugAntilog(coroutinesSuffix = false))
+}
+```
 
 * Call initialize code from ios project.
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ Napier.base(DebugAntilog())
 
 #### iOS
 
-* Write initialize code in your kotlin mpp project.
+* Write initialize code in your Darwin source set of kotlin mpp project.
 
 ```kotlin
+// NapierProxy.kt
 fun debugBuild() {
     Napier.base(DebugAntilog())
 }


### PR DESCRIPTION
improve README:
I was wondered where `NapierProxyKt` is defined. -> describe filename.
Markdown table format was broken -> add example instead.