### PR TITLE
Add support for watchosDeviceArm64

### DIFF
--- a/napier/build.gradle.kts
+++ b/napier/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         macosArm64()
         iosArm64()
         watchosArm64()
+        watchosDeviceArm64()
         tvosArm64()
         iosSimulatorArm64()
         watchosSimulatorArm64()
@@ -43,6 +44,7 @@ kotlin {
             macosArm64()
             iosArm64()
             watchosArm64()
+            watchosDeviceArm64()
             tvosArm64()
             iosSimulatorArm64()
             watchosSimulatorArm64()
@@ -155,6 +157,12 @@ kotlin {
             val watchosArm64Test by getting {
                 dependsOn(darwinTest)
             }
+            val watchosDeviceArm64Main by getting {
+                dependsOn(darwinMain)
+            }
+            val watchosDeviceArm64Test by getting {
+                dependsOn(darwinTest)
+            }
             val tvosArm64Main by getting {
                 dependsOn(darwinMain)
             }
@@ -198,6 +206,12 @@ kotlin {
                     dependsOn(darwinMain)
                 }
                 val watchosArm64Test by getting {
+                    dependsOn(darwinTest)
+                }
+                val watchosDeviceArm64Main by getting {
+                    dependsOn(darwinMain)
+                }
+                val watchosDeviceArm64Test by getting {
                     dependsOn(darwinTest)
                 }
                 val tvosArm64Main by getting {


### PR DESCRIPTION
This is a tiny PR adding support for the new-ish watchosDeviceArm64 target. Without this target this library can't be used on watchOS as the resulting binaries miss the arm64 target required by Xcode 15 and 16.