### PR TITLE
Change: Do lazy evaluation of lambda messages

### DIFF
--- a/napier/src/commonMain/kotlin/io/github/aakira/napier/Napier.kt
+++ b/napier/src/commonMain/kotlin/io/github/aakira/napier/Napier.kt
@@ -73,7 +73,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun v(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.VERBOSE, tag, throwable, message())
+        log(LogLevel.VERBOSE, tag, throwable, message)
     }
 
     /** Send a INFO log message and log the exception.
@@ -95,7 +95,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun i(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.INFO, tag, throwable, message())
+        log(LogLevel.INFO, tag, throwable, message)
     }
 
     /** Send a DEBUG log message and log the exception.
@@ -117,7 +117,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun d(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.DEBUG, tag, throwable, message())
+        log(LogLevel.DEBUG, tag, throwable, message)
     }
 
     /** Send a WARN log message and log the exception.
@@ -139,7 +139,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun w(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.WARNING, tag, throwable, message())
+        log(LogLevel.WARNING, tag, throwable, message)
     }
 
     /** Send a ERROR log message and log the exception.
@@ -161,7 +161,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun e(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.ERROR, tag, throwable, message())
+        log(LogLevel.ERROR, tag, throwable, message)
     }
 
     /** What a Terrible Failure: Report an exception that should never happen.
@@ -183,7 +183,7 @@ object Napier {
      * @param message Lambda: The message you would like logged. This value cannot be null.
      */
     fun wtf(throwable: Throwable? = null, tag: String? = null, message: () -> String) {
-        log(LogLevel.ASSERT, tag, throwable, message())
+        log(LogLevel.ASSERT, tag, throwable, message)
     }
 
     /** Low-level logging call.
@@ -200,9 +200,27 @@ object Napier {
         tag: String? = null,
         throwable: Throwable? = null,
         message: String
+    ) = log(priority, tag, throwable) {
+        message
+    }
+
+    /** Low-level logging call.
+     *
+     * @param priority enum: The priority/type of this log message Value is ASSERT,
+     * ERROR, WARN, INFO, DEBUG, or VERBOSE
+     * @param tag String: Used to identify the source of a log message. It usually
+     * identifies the class or activity where the log call occurs. This value may be null.
+     * @param throwable Throwable: An exception to log This value may be null.
+     * @param message Lambda: The message you would like logged. This value cannot be null.
+     */
+    fun log(
+        priority: LogLevel,
+        tag: String? = null,
+        throwable: Throwable? = null,
+        message: () -> String
     ) {
         if (isEnable(priority, tag)) {
-            rawLog(priority, tag, throwable, message)
+            rawLog(priority, tag, throwable, message())
         }
     }
 
@@ -239,5 +257,5 @@ fun log(
     tag: String? = null,
     message: () -> String,
 ) {
-    Napier.log(priority, tag, throwable, message())
+    Napier.log(priority, tag, throwable, message)
 }


### PR DESCRIPTION
Unsure whether this is wanted, but it surely bugged my mind why speed didn't improve after moving large string calculation into lambda.

This may break code for existing implementations that rely on the lambda to be executed all the time, so maybe change this in a future major release?